### PR TITLE
add shared library type in binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
   'targets': [
     {
       'target_name': 'node-native-ocr',
+      'type': "shared_library",
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',


### PR DESCRIPTION
this the potential fix for Dylib symbol not found error.