### PR TITLE
Support deprecation of remote

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ let bindings
 
 const isElectron = process.versions.hasOwnProperty('electron')
 
-if(isElectron) {
-
-  const appPath = require("electron").remote.app.getAppPath()
+if (isElectron) {
+  const electron = require("electron")
+  const appPath = (electron.remote?.app || electron.app).getAppPath()
   const ocrPackagePath = 'node_modules/node-native-ocr'
   const modulePath = path.resolve(appPath, ocrPackagePath, 'build/Release/node-native-ocr')
   console.log('modulePath', modulePath)
@@ -13,10 +13,10 @@ if(isElectron) {
   process.env.TESSDATA_PREFIX = tessdataPath
   console.log('tessdataPath', tessdataPath)
   bindings = __non_webpack_require__(modulePath)
-  
+
 } else {
 
-  const tessdataPath = path.resolve(__dirname,"..","tessdata")
+  const tessdataPath = path.resolve(__dirname, "..", "tessdata")
   process.env.TESSDATA_PREFIX = tessdataPath
   bindings = require('../build/Release/node-native-ocr.node')
 }
@@ -40,13 +40,13 @@ const handleOptions = ({
 
 
 const makePromise = (method) => {
-  
+
   return (arg, options) => new Promise((resolve, reject) => {
     options = handleOptions(options)
-    
+
     bindings[method](arg, options.lang, (err, text) => {
       if (err) {
-        console.log('errrror:', err)
+        console.log('error:', err)
         const error = new Error(text)
         error.code = err
         return reject(error)


### PR DESCRIPTION
[Remote is deprecated per the docs](https://www.electronjs.org/docs/api/remote) and the app object can only be accessed on main. This change will allow the continued support of remote, but if remote is unavailable (as it can be in some electron configurations), it will use electron.app, which is available in main.