### PR TITLE
Added Typescript declaration files

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,7 @@
+export const recognize: (image: Buffer, options?: RecognizeOptions) => Promise<string>;
+
+export interface RecognizeOptions {
+  lang?: string | Array<string>;
+  output?: 'txt' | 'tsv';
+  tessdataPath?: string,
+}

--- a/dist/index.d.ts.map
+++ b/dist/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":"AAgDS,uDAeL"}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "gypfile": true,
   "main": "lib/index.js",
   "module": "src/index.js",
+  "types": "./dist/index.d.ts",
   "devDependencies": {
     "ava": "^0.16.0",
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Added Typescript declaration files for the `recognize` API.

Considered adding automatic declarations via the addition of a `tsconfig.json`, however the auto-generated declarations were ambiguous:

```
export function recognize(arg: any, options: any): any;
```

Although these would be sufficient to unblock future Typescript integrations, by manually defining the declarations it will support easier integration through IDE suggestions at the cost of requiring manual maintenance if the API changes in the future.