### PR TITLE
Limit nyc coverage reports to Linux builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-11, window-2019 ]
+        os: [ ubuntu-20.04, macos-11, windows-2019 ]
         node: [ "18" ]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-11 ]
+        os: [ ubuntu-20.04, macos-11, window-2019 ]
         node: [ "18" ]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: Run CI
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -33,7 +33,7 @@ jobs:
   prebuild-node:
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-20.04, windows-2019 ]
         node: [ 16.13.0 ]
         runtime: [ node ]
         arch: [ x64 ]

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "create-prebuild": "prebuild -t 3 -r napi",
     "// test": "lldb -- /usr/local/bin/node ./node_modules/.bin/ava --verbose --timeout=10s",
     "test": "npm run test-js",
-    "test-js": "nyc ava --verbose --timeout=10s",
+    "test-js": "run-script-os",
+    "test-js:nix": "nyc ava --verbose --timeout=10s",
+    "test-js:windows": "ava --verbose --timeout=10s",
     "report-cov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "prepack": "npm run clean-tesseract && node ./scripts/prepack"
   },

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "// test": "lldb -- /usr/local/bin/node ./node_modules/.bin/ava --verbose --timeout=10s",
     "test": "npm run test-js",
     "test-js": "run-script-os",
-    "test-js:nix": "nyc ava --verbose --timeout=10s",
-    "test-js:windows": "ava --verbose --timeout=10s",
+    "test-js:linux": "nyc ava --verbose --timeout=10s",
+    "test-js:default": "ava --verbose --timeout=10s",
     "report-cov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "prepack": "npm run clean-tesseract && node ./scripts/prepack"
   },


### PR DESCRIPTION
No need for per-platform coverage reports + it avoids errors with nyc on Windows